### PR TITLE
Change verify return format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,7 @@ class PluginPassportOAuth {
           return this.context.accessors.execute(new this.context.constructors.Request(request.original, req))
             .then(res => Promise.resolve({kuid: res.result._id, message: null}));
         }
-        return Promise.resolve({kuid: false, message: `Could not login with strategy "${profile.provider}"`});
+        return Promise.resolve({kuid: null, message: `Could not login with strategy "${profile.provider}"`});
       })
       .catch(err => Promise.reject(err));
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,7 @@ class PluginPassportOAuth {
         let req = null;
 
         if (userObject !== null) {
-          return Promise.resolve(userObject.kuid);
+          return Promise.resolve({kuid: userObject.kuid, message: null});
         }
 
         if (this.config.strategies[profile.provider].persist.length !== 0) {
@@ -201,9 +201,9 @@ class PluginPassportOAuth {
           req.body.credentials[profile.provider] = user;
 
           return this.context.accessors.execute(new this.context.constructors.Request(request.original, req))
-            .then(res => Promise.resolve(res.result._id));
+            .then(res => Promise.resolve({kuid: res.result._id, message: null}));
         }
-        return Promise.resolve(null);
+        return Promise.resolve({kuid: false, message: `Could not login with strategy "${profile.provider}"`});
       })
       .catch(err => Promise.reject(err));
   }

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -27,7 +27,7 @@ describe('#verify', () => {
 
   it('should resolve an existing user', () => {
     pluginOauth.getProviderRepository = sandbox.stub().returns({get: sandbox.stub().returns(Promise.resolve({kuid: '24'}))});
-    return should(pluginOauth.verify(null, null, null, {provider: 'facebook', _json: {id: '42'}})).be.fulfilledWith('24');
+    return should(pluginOauth.verify(null, null, null, {provider: 'facebook', _json: {id: '42'}})).be.fulfilledWith({kuid: '24', message: null});
   });
 
   it('should resolve with the new user id and persist it', (done) => {
@@ -54,6 +54,6 @@ describe('#verify', () => {
     };
     const promise = pluginOauth.verify({}, null, null, {provider: 'facebook', _json: {id: '42', name: 'foo', displayName: 'Displayed name'}});
 
-    return should(promise).be.fulfilledWith('42');
+    return should(promise).be.fulfilledWith({kuid: '42', message: null});
   });
 });


### PR DESCRIPTION
Verify now returns an object like 
```json
{"kuid": "kuid", 
"message": "message"}
```
kuid would be null if there is an error and message would contain the reason of the error.
message would be null if there is no error and kuid would represent the id of the user in Kuzzle.