### PR TITLE
Change strategy definition depending on kuzzle version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const
   refresh = require('passport-oauth2-refresh'),
+  semver = require('semver'),
   defaultConfig = {},
   storageMapping = {
     configuration: {
@@ -29,7 +30,8 @@ class PluginPassportOAuth {
     this.context = null;
     this.scope = {};
     this.config = null;
-    this.strategyConstructor = null;
+    this.authenticators = {};
+    this.strategies = null;
   }
 
   /**
@@ -46,7 +48,7 @@ class PluginPassportOAuth {
     if (!this.config.strategies || Object.keys(this.config.strategies).length === 0) {
       /*eslint no-console: 0*/
       console.warn('[kuzzle-plugin-auth-passport-oauth] No strategies specified.');
-      return Promise.resolve(); 
+      return Promise.resolve();
     }
 
     this.context = context;
@@ -57,43 +59,47 @@ class PluginPassportOAuth {
 
     return this.context.accessors.storage.bootstrap(storageMapping)
       .then(() => {
-        return new Promise((resolve, reject) => {
-          this.strategies = {};
-          Object.keys(this.config.strategies).forEach(strategy => {
-            if (!this.config.strategies[strategy].credentials) {
-              return reject(new this.context.errors.BadRequestError(`Error loading strategy [${strategy}]: no credentials provided`));
-            }
+        this.strategies = {};
+        Object.keys(this.config.strategies).forEach(strategy => {
+          if (!this.config.strategies[strategy].credentials) {
+            throw new this.context.errors.BadRequestError(`Error loading strategy [${strategy}]: no credentials provided`);
+          }
 
-            try {
-              this.strategyConstructor = require('passport-' + strategy).Strategy;
-            } catch (err) {
-              return reject(new this.context.errors.BadRequestError(`Error loading strategy [${strategy}]: ${err.message}`));
-            }
+          try {
+            this.authenticators[strategy] = require('passport-' + strategy).Strategy;
+          } catch (err) {
+            throw new this.context.errors.BadRequestError(`Error loading strategy [${strategy}]: ${err.message}`);
+          }
 
-            this.strategies[strategy] = {
-              config: {
-                constructor: this.strategyConstructor,
-                strategyOptions: this.config.strategies[strategy].credentials,
-                authenticateOptions: {
-                  scope: this.config.strategies[strategy].scope
-                },
-                fields: this.config.strategies[strategy].persist
+          this.strategies[strategy] = {
+            config: {
+              strategyOptions: this.config.strategies[strategy].credentials,
+              authenticateOptions: {
+                scope: this.config.strategies[strategy].scope
               },
-              methods: {
-                create: 'create',
-                delete: 'delete',
-                exists: 'exists',
-                getInfo: 'getInfo',
-                update: 'update',
-                validate: 'validate',
-                verify: 'verify',
-                afterRegister: 'afterRegister',
-                getById: 'getById'
-              }
-            };
-          });
+              fields: this.config.strategies[strategy].persist
+            },
+            methods: {
+              create: 'create',
+              delete: 'delete',
+              exists: 'exists',
+              getInfo: 'getInfo',
+              update: 'update',
+              validate: 'validate',
+              verify: 'verify',
+              afterRegister: 'afterRegister',
+              getById: 'getById'
+            }
+          };
 
-          return resolve();
+          // This snippet simply suppresses a warning emitted by Kuzzle during
+          // plugin initialization.
+          // See https://github.com/kuzzleio/kuzzle/pull/1145
+          if (semver.lt(this.context.config.version, '1.4.0')) {
+            this.strategies[strategy].config.constructor = this.authenticators[strategy];
+          } else {
+            this.strategies[strategy].config.authenticator = strategy;
+          }
         });
       });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -3487,8 +3487,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "passport-google-oauth20": "^1.0.0",
     "passport-oauth2": "1.x.x",
     "passport-oauth2-refresh": "1.1.0",
-    "passport-twitter": "^1.0.4"
+    "passport-twitter": "^1.0.4",
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "eslint": "5.0.1",

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -45,11 +45,63 @@ describe('#init', () => {
     }, pluginContext)).be.rejectedWith('Error loading strategy [fake]: Cannot find module \'passport-fake\'');
   });
 
-  it('should initialize all strategies', done => {
-    pluginOauth.init(config, pluginContext)
+  it('should initialize all strategies', () => {
+    return pluginOauth.init(config, pluginContext)
       .then(() => {
-        should(pluginOauth.strategies).be.Object();
-        done();
+        should(pluginOauth.strategies).be.Object().and.match({
+          facebook: {
+            config: {
+              authenticator: 'facebook',
+              strategyOptions: {
+                clientId: 'clientId',
+                secret: 'secret'
+              },
+              authenticateOptions: {}
+            },
+            methods: {
+              afterRegister: 'afterRegister',
+              create: 'create',
+              delete: 'delete',
+              exists: 'exists',
+              getById: 'getById',
+              getInfo: 'getInfo',
+              update: 'update',
+              validate: 'validate',
+              verify: 'verify'
+            }
+          }
+        });
+      });
+  });
+
+  it('should expose a constructor property to Kuzzle pre-1.4.0', () => {
+    pluginContext.config.version = '1.3.999';
+    return pluginOauth.init(config, pluginContext)
+      .then(() => {
+        pluginContext.config.version = '1.4.0';
+        should(pluginOauth.strategies).be.Object().and.match({
+          facebook: {
+            config: {
+              constructor: () => {},
+              strategyOptions: {
+                clientId: 'clientId',
+                secret: 'secret'
+              },
+              authenticateOptions: {}
+            },
+            methods: {
+              afterRegister: 'afterRegister',
+              create: 'create',
+              delete: 'delete',
+              exists: 'exists',
+              getById: 'getById',
+              getInfo: 'getInfo',
+              update: 'update',
+              validate: 'validate',
+              verify: 'verify'
+            }
+          }
+        });
       });
   });
 });

--- a/test/mock/pluginContext.mock.js
+++ b/test/mock/pluginContext.mock.js
@@ -7,6 +7,9 @@ module.exports = {
     Repository: sinon.stub(),
     Request: sinon.stub()
   },
+  config: {
+    version: '1.4.0'
+  },
   accessors: {
     storage: {
       bootstrap: sinon.stub().returns(Promise.resolve())


### PR DESCRIPTION
## What does this PR do?

Remove the following warning, issued by Kuzzle during startup, and introduced by https://github.com/kuzzleio/kuzzle/pull/1145 :
```
[kuzzle-plugin-auth-passport-local] Strategy local: the strategy "constructor" property is deprecated, please use "authenticator" instead (see https://tinyurl.com/y7boozbk)
```

This PR is purely cosmetic. It does not introduce any change and has no side-effect.
