### PR TITLE
Fix verify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,6 +207,7 @@ class PluginPassportOAuth {
           return this.context.accessors.execute(new this.context.constructors.Request(request.original, req, {refresh: 'wait_for'}))
             .then(res => Promise.resolve({kuid: res.result._id, message: null}));
         }
+        return Promise.reject(new NotFoundError());
       });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const
     }
   },
   {
+    Error,
     NotFoundError
   } = require('kuzzle-common-objects').errors;
 
@@ -175,39 +176,37 @@ class PluginPassportOAuth {
           return Promise.resolve({kuid: userObject.kuid, message: null});
         }
 
-        return Promise.reject({message: `Could not login with strategy "${profile.provider}"`});
+        throw new Error(`Could not login with strategy "${profile.provider}"`);
       })
       .catch(err => {
         if (!(err instanceof NotFoundError)) {
-          return Promise.reject(err);
+          throw err;
         }
 
-        let req = null;
-
-        if (this.config.strategies[profile.provider].persist.length !== 0) {
-          Object.keys(profile._json).forEach(attr => {
-            if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {
-              user[attr] = profile._json[attr];
-            }
-          });
-
-          req = {
-            controller: 'security',
-            action: 'createUser',
-            body: {
-              content: {
-                profileIds: this.config.defaultProfiles ? this.config.defaultProfiles : ['default']
-              }, // content will be persisted in Kuzzle
-              credentials: {} // credentials will be persisted in the repository
-            }
-          };
-
-          req.body.credentials[profile.provider] = user;
-
-          return this.context.accessors.execute(new this.context.constructors.Request(request.original, req, {refresh: 'wait_for'}))
-            .then(res => Promise.resolve({kuid: res.result._id, message: null}));
+        if (this.config.strategies[profile.provider].persist.length === 0) {
+          throw new NotFoundError();
         }
-        return Promise.reject(new NotFoundError());
+        Object.keys(profile._json).forEach(attr => {
+          if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {
+            user[attr] = profile._json[attr];
+          }
+        });
+
+        const req = {
+          controller: 'security',
+          action: 'createUser',
+          body: {
+            content: {
+              profileIds: this.config.defaultProfiles ? this.config.defaultProfiles : ['default']
+            }, // content will be persisted in Kuzzle
+            credentials: {} // credentials will be persisted in the repository
+          }
+        };
+
+        req.body.credentials[profile.provider] = user;
+
+        return this.context.accessors.execute(new this.context.constructors.Request(request.original, req, {refresh: 'wait_for'}))
+          .then(res => Promise.resolve({kuid: res.result._id, message: null}));
       });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const
     }
   },
   {
-    Error,
+    ForbiddenError,
     NotFoundError
   } = require('kuzzle-common-objects').errors;
 
@@ -176,7 +176,7 @@ class PluginPassportOAuth {
           return Promise.resolve({kuid: userObject.kuid, message: null});
         }
 
-        throw new Error(`Could not login with strategy "${profile.provider}"`);
+        throw new ForbiddenError(`Could not login with strategy "${profile.provider}"`);
       })
       .catch(err => {
         if (!(err instanceof NotFoundError)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,10 @@ const
         }
       }
     }
-  };
+  },
+  {
+    NotFoundError
+  } = require('kuzzle-common-objects').errors;
 
 /**
  * @class PluginPassportOAuth
@@ -175,8 +178,8 @@ class PluginPassportOAuth {
         return Promise.resolve({kuid: null, message: `Could not login with strategy "${profile.provider}"`});
       })
       .catch(err => {
-        if (error instanceof NotFoundError) {
-          return Promise.reject(err)
+        if (!(err instanceof NotFoundError)) {
+          return Promise.reject(err);
         }
 
         let req = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,11 +168,18 @@ class PluginPassportOAuth {
     return this.getProviderRepository(profile.provider)
       .get(profile._json[this.config.strategies[profile.provider].identifierAttribute])
       .then(userObject => {
-        let req = null;
-
         if (userObject !== null) {
           return Promise.resolve({kuid: userObject.kuid, message: null});
         }
+
+        return Promise.resolve({kuid: null, message: `Could not login with strategy "${profile.provider}"`});
+      })
+      .catch(err => {
+        if (error instanceof NotFoundError) {
+          return Promise.reject(err)
+        }
+
+        let req = null;
 
         if (this.config.strategies[profile.provider].persist.length !== 0) {
           Object.keys(profile._json).forEach(attr => {
@@ -197,9 +204,7 @@ class PluginPassportOAuth {
           return this.context.accessors.execute(new this.context.constructors.Request(request.original, req, {refresh: 'wait_for'}))
             .then(res => Promise.resolve({kuid: res.result._id, message: null}));
         }
-        return Promise.resolve({kuid: null, message: `Could not login with strategy "${profile.provider}"`});
-      })
-      .catch(err => Promise.reject(err));
+      });
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ class PluginPassportOAuth {
           return Promise.resolve({kuid: userObject.kuid, message: null});
         }
 
-        return Promise.resolve({kuid: null, message: `Could not login with strategy "${profile.provider}"`});
+        return Promise.reject({message: `Could not login with strategy "${profile.provider}"`});
       })
       .catch(err => {
         if (!(err instanceof NotFoundError)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,7 +184,7 @@ class PluginPassportOAuth {
         }
 
         if (this.config.strategies[profile.provider].persist.length === 0) {
-          throw new NotFoundError();
+          throw new NotFoundError('There is nothing to persist in the plugin configuration.');
         }
         Object.keys(profile._json).forEach(attr => {
           if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -894,6 +894,14 @@
       "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
       "dev": true
     },
+    "kuzzle-common-objects": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/kuzzle-common-objects/-/kuzzle-common-objects-3.0.13.tgz",
+      "integrity": "sha1-HTrB7ARi25lqUwoR4LT6JdCnevE=",
+      "requires": {
+        "uuid": "^3.3.2"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2734,6 +2742,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "kuzzle-common-objects": "^3.0.13",
     "passport": "0.4.0",
     "passport-facebook": "^2.1.1",
     "passport-github": "^1.1.0",

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,7 +1,10 @@
 const
   should = require('should'),
   PluginOAuth = require('../lib'),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  {
+    NotFoundError
+  } = require('kuzzle-common-objects').errors;
 
 describe('#verify', () => {
   let
@@ -31,7 +34,7 @@ describe('#verify', () => {
   });
 
   it('should resolve with the new user id and persist it', () => {
-    pluginOauth.getProviderRepository = sinon.stub().returns({get: sinon.stub().resolves(null)});
+    pluginOauth.getProviderRepository = sinon.stub().returns({get: sinon.stub().rejects(new NotFoundError())});
     pluginOauth.config.strategies.facebook.persist = ['name'];
 
     return pluginOauth.verify({}, null, null, {provider: 'facebook', _json: {id: '42', name: 'foo'}})
@@ -44,7 +47,7 @@ describe('#verify', () => {
   it('should resolve with the new user id and persist it with some mapping', (done) => {
     let status = 'pending';
 
-    pluginOauth.getProviderRepository = sinon.stub().returns({get: sinon.stub().resolves(null)});
+    pluginOauth.getProviderRepository = sinon.stub().returns({get: sinon.stub().rejects(new NotFoundError())});
     pluginOauth.context.constructors.Request = sinon.stub().callsFake(() => {
       try {
         status = 'verified';


### PR DESCRIPTION
## What does this PR do ?

The load method of repository from Kuzzle now throws a NotFoundError instead of returning a null user object so in the plugin we now create the new user in the .catch() if the error is an instance of NotFoundError.
