### PR TITLE
Add a feature to rename attributes from the provider in Kuzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here is an example of a configuration:
                 "public_profile"
             ],
             "kuzzleAttributesMapping": {
-              "userMail": "email"
+              "userMail": "email" // will store the attribute "email" as "userEmail" into Kuzzle
             },
             "identifierAttribute": "id"
         }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ List of available configurations:
 | ``identifierAttribute`` | | String | Attribute from the profile of the provider to use as Id if you want to persist the user in Kuzzle |
 | ``defaultProfile`` | ``"default"`` | Array | Profiles of the new persisted user |
 | ``kuzzleAttributesMapping`` | ```` | Object | Mapping of attributes to persist in the user persisted in Kuzzle |
-| ``passportStrategy`` | String | Strategy name for passport (eg. google-oauth20 while the name of the provider is google)
+| ``passportStrategy`` | ```` | String | Strategy name for passport (eg. google-oauth20 while the name of the provider is google)
 
 Here is an example of a configuration:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,6 +185,8 @@ class PluginPassportOAuth {
         Object.keys(profile._json).forEach(attr => {
           if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {
             if (this.config.strategies[profile.provider].kuzzleAttributesMapping) {
+              const key = this.config.strategies[profile.provider].kuzzleAttributesMapping && this.config.strategies[profile.provider].kuzzleAttributesMapping[attr] || attr;
+              user[key] = profile._json[attr];
               user[this.config.strategies[profile.provider].kuzzleAttributesMapping[attr]||attr] = profile._json[attr];
             } else {
               user[attr] = profile._json[attr];

--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,6 @@ class PluginPassportOAuth {
       })
       .catch(err => {
         if (!(err instanceof this.context.errors.NotFoundError)) {
-          console.log(err);
           throw err;
         }
 
@@ -185,7 +184,11 @@ class PluginPassportOAuth {
         }
         Object.keys(profile._json).forEach(attr => {
           if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {
-            user[attr] = profile._json[attr];
+            if (this.config.strategies[profile.provider].kuzzleAttributesMapping) {
+              user[this.config.strategies[profile.provider].kuzzleAttributesMapping[attr]||attr] = profile._json[attr];
+            } else {
+              user[attr] = profile._json[attr];
+            }
           }
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-oauth",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-oauth",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Kuzzle plugin to log-in users through passport's strategies",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
## What does this PR do ?

Add a feature where you can rename an attribute received from the provider into kuzzle.
ex:
```
KuzzleAttributesMapping: {
 name: "myName"
}
```
The name of the user pushed in kuzzle will be rename by myName in the credentials.