### PR TITLE
Fix Repository.get throwing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Plugin Passport OAUTH Authentication
 
-This plugin provides an authentication with [Passeport.js strategies](http://passportjs.org/docs).
+This plugin provides OAUTH2 authentication using [Passport.js strategies](http://passportjs.org/docs).
 
 ## Compatibility matrice
 
@@ -13,7 +13,7 @@ This plugin provides an authentication with [Passeport.js strategies](http://pas
 
 # Configuration
 
-To edit the configuration of a plugin see [custom plugin configuration](https://docs.kuzzle.io/plugins/2/essentials/getting-started/#configuration).
+To edit the configuration of a plugin see [custom plugin configuration](https://docs.kuzzle.io/core/2/guides/essentials/configuration).
 
 List of available configurations:
 
@@ -67,8 +67,8 @@ Here is an example of a configuration:
 
 The easiest way to implement an oauth authentication in your front-end is to use the [sdk login oauth popup module](https://github.com/kuzzleio/kuzzle-sdk-login-oauth-popup)
 
-See [Kuzzle API Documentation](https://docs.kuzzle.io/guide/2/essentials/user-authentication/) for more details about Kuzzle authentication mechanism.
+See [Kuzzle API Documentation](https://docs.kuzzle.io/core/2/guides/essentials/user-authentication/) for more details about Kuzzle authentication mechanism.
 
 # How to create a plugin
 
-See [Kuzzle documentation](https://docs.kuzzle.io/plugins/2/essentials/strategies/) about plugin for more information about how to create your own plugin.
+See [Kuzzle documentation](https://docs.kuzzle.io/core/2/plugins/essentials/introduction/) for more information about how to create your own plugin.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ List of available configurations:
 |------|---------------|-----------|-----------------------------|
 | ``strategies`` | ``{}`` | Object | List of the providers you want to use with passport |
 | ``credentials`` | ``{}`` | Object | Credentials provided by the provider |
-| ``persist`` | ``{}`` | Object | Attributes you want to persist if the user doesn't exist |
+| ``persist`` | ``{}`` | Object | Attributes you want to persist in the user credentials object if the user doesn't exist |
 | ``scope`` | ``[]`` | Array | List of fields in the OAUTH 2.0 scope of access |
-| ``identifierAttribute`` | | String | Attribute from the profile of the provider to use as Id if you want to persist the user in Kuzzle |
-| ``defaultProfile`` | ``"default"`` | Array | Profiles of the new persisted user |
+| ``identifierAttribute`` | | String | Attribute from the profile of the provider to use as unique identifier if you want to persist the user in Kuzzle |
+| ``defaultProfile`` | ``["default"]`` | Array | Profiles of the new persisted user |
 | ``kuzzleAttributesMapping`` | ``{}`` | Object | Mapping of attributes to persist in the user persisted in Kuzzle |
 | ``passportStrategy`` | ``''`` | String | Strategy name for passport (eg. google-oauth20 while the name of the provider is google)
 
@@ -32,34 +32,88 @@ Here is an example of a configuration:
 
 ```js
 {
-    "strategies": {
-        "facebook": {
-            "passportStrategy": "facebook",
-            "credentials": {
-                "clientID": "<your-client-id>",
-                "clientSecret": "<your-client-secret>",
-                "callbackURL": "http://localhost:8080/_login/facebook",
-                "profileFields": ["id", "name", "picture", "email", "gender"]
-            },
-            "persist": [
-                "login",
-                "avatar_url",
-                "name",
-                "email"
-            ],
-            "scope": [
-                "email",
-                "public_profile"
-            ],
-            "kuzzleAttributesMapping": {
-              "userMail": "email" // will store the attribute "email" as "userEmail" into Kuzzle
-            },
-            "identifierAttribute": "id"
-        }
-    },
-    "defaultProfiles": [
-        "default"
-    ]
+  "strategies": {
+    "facebook": {
+      "passportStrategy": "facebook",
+      "credentials": {
+        "clientID": "<your-client-id>",
+        "clientSecret": "<your-client-secret>",
+        "callbackURL": "http://localhost:8080/_login/facebook",
+        "profileFields": ["id", "name", "picture", "email", "gender"]
+      },
+      "persist": [
+        "picture.data.url",
+        "last_name",
+        "first_name",
+        "email"
+      ],
+      "scope": [
+        "email",
+        "public_profile"
+      ],
+      "kuzzleAttributesMapping": {
+        "userMail": "email" // will store the attribute "email" as "userEmail" into the user credentials object
+      },
+      "identifierAttribute": "email"
+    }
+  },
+  "defaultProfiles": [
+    "default"
+  ]
+}
+```
+
+## identifierAttribute
+
+This attribute will be used to identify your users. It has to be unique.  
+
+You need to choose an attribute declared in the `persist` array.
+
+## Attribute persistence
+
+Attributes declared in the `persist` array will be persisted in the credentials object and not in the user content.  
+
+For example, if you have the following configuration:
+```js
+{
+  "strategies": {
+    "facebook": {
+      "persist": ["email", "first_name", "picture.data.url"],
+      "kuzzleAttributesMapping": {
+        "picture.data.url": "avatar_url"
+      }
+    }
+  }
+}
+```
+
+And your OAuth provider will send you the following `_json` payload:
+```js
+{
+  "email": "gfreeman@black-mesa.xen",
+  "first_name": "gordon",
+  "last_name": "freeman",
+  "picture": {
+    "data": {
+      "url": "http://avatar.url"
+    }
+  }
+}
+```
+
+The created user content will be:
+```js
+{
+  "content": {
+    "profileIds": ["default"]
+  },
+  "credentials": {
+    "facebook": {
+      "email": "gfreeman@black-mesa.xen",
+      "first_name": "gordon",
+      "avatar_url": "http://avatar.url"
+    }
+  }
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
-const refresh = require('passport-oauth2-refresh');
 const assert = require('assert');
+const get = require('lodash.get');
+const set = require('lodash.set');
+const refresh = require('passport-oauth2-refresh');
 
 /**
  * @class PluginPassportOAuth
@@ -52,8 +54,8 @@ class PluginPassportOAuth {
       return;
     }
 
-    for (const key of Object.keys(this.config.strategies)) {
-      this.scope[key] = this.config.strategies[key].scope;
+    for (const [strategy, definition] of Object.keys(this.config.strategies)) {
+      this.scope[strategy] = definition.scope;
     }
 
     await this.context.accessors.storage.bootstrap(this.storageMappings);
@@ -73,7 +75,7 @@ class PluginPassportOAuth {
         this.authenticators[name] = require('passport-' + (strategy.passportStrategy || name)).Strategy;
       }
       catch (error) {
-        throw new Error(`Error loading strategy [${name}]: ${error.message}`);
+        throw new this.context.errors.BadRequestError(`Error loading strategy [${name}]: ${error.message}`);
       }
 
       this.strategies[name] = {
@@ -145,26 +147,24 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  getCredentialsFromKuid(kuid, provider) {
-    return this.getProviderRepository(provider).search({
-      query: {
-        term: {
-          kuid
-        }
-      }
-    })
-      .then(result => {
-        if (result.total === 0) {
-          return Promise.resolve(null);
-        }
+  async getCredentialsFromKuid(kuid, provider) {
+    const query = {
+      term: { kuid }
+    };
 
-        return Promise.resolve(result.hits[0]);
-      });
+    const result = await this.getProviderRepository(provider).search({ query });
+
+    if (result.total === 0) {
+      throw new this.context.errors.NotFoundError(`A strategy does not exist for the user "${kuid}".`);
+    }
+
+    return result.hits[0];
   }
 
   /**
    * Verify function called by passport to log the user.
-   * If a persist option is in the configuration of the strategy then every field present in this configuration will be persisted in the repository.
+   * If a persist option is in the configuration of the strategy then every field
+   * present in this configuration will be persisted in the repository.
    *
    * @param request
    * @param accessToken
@@ -172,55 +172,57 @@ class PluginPassportOAuth {
    * @param profile
    * @returns {Promise.<T>}
    */
-  verify(request, accessToken, refreshToken, profile) {
-    const
-      user = {};
+  async verify(request, accessToken, refreshToken, profile) {
+    const strategy = this.config.strategies[profile.provider];
 
-    return this.getProviderRepository(profile.provider)
-      .get(profile._json[this.config.strategies[profile.provider].identifierAttribute])
-      .then(userObject => {
-        if (userObject !== null) {
-          return Promise.resolve({kuid: userObject.kuid, message: null});
-        }
+    if (strategy.persist.length === 0) {
+      throw new this.context.errors.NotFoundError(`There is nothing to persist for strategy "${profile.provider}".`);
+    }
 
-        throw new this.context.errors.ForbiddenError(`Could not login with strategy "${profile.provider}"`);
-      })
-      .catch(err => {
-        if (!(err instanceof this.context.errors.NotFoundError)) {
-          throw err;
-        }
+    try {
+      const user = await this.getProviderRepository(profile.provider).get(profile._json[strategy.identifierAttribute]);
 
-        if (this.config.strategies[profile.provider].persist.length === 0) {
-          throw new this.context.errors.NotFoundError('There is nothing to persist in the plugin configuration.');
-        }
-        Object.keys(profile._json).forEach(attr => {
-          if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {
-            if (this.config.strategies[profile.provider].kuzzleAttributesMapping) {
-              const key = this.config.strategies[profile.provider].kuzzleAttributesMapping && this.config.strategies[profile.provider].kuzzleAttributesMapping[attr] || attr;
-              user[key] = profile._json[attr];
-              user[this.config.strategies[profile.provider].kuzzleAttributesMapping[attr]||attr] = profile._json[attr];
-            } else {
-              user[attr] = profile._json[attr];
-            }
-          }
-        });
+      return { kuid: user.kuid };
+    }
+    catch (error) {
+      if (error.id !== 'services.storage.not_found') {
+        throw error;
+      }
+    }
 
-        const req = {
-          controller: 'security',
-          action: 'createUser',
-          body: {
-            content: {
-              profileIds: this.config.defaultProfiles ? this.config.defaultProfiles : ['default']
-            }, // content will be persisted in Kuzzle
-            credentials: {} // credentials will be persisted in the repository
-          }
-        };
+    // Use an object with flattened key because the "kuzzleAttributesMapping" object
+    // use lodash style path
+    const flattenedObject = flatObject(profile._json);
 
-        req.body.credentials[profile.provider] = user;
+    const userCredentials = {};
 
-        return this.context.accessors.execute(new this.context.constructors.Request(request.original, req, {refresh: 'wait_for'}))
-          .then(res => Promise.resolve({kuid: res.result._id, message: null}));
-      });
+    for (const [attribute, value] of Object.entries(flattenedObject)) {
+      if (! strategy.persist.includes(attribute)) {
+        continue;
+      }
+
+      const mappedAttributeName = get(strategy.kuzzleAttributesMapping, attribute);
+
+      if (mappedAttributeName) {
+        set(userCredentials, mappedAttributeName, value);
+      }
+      else {
+        set(userCredentials, attribute, value);
+      }
+    }
+
+    const userBody = {
+      content: {
+        profileIds: this.config.defaultProfiles || ['default']
+      },
+      credentials: {
+        [profile.provider]: userCredentials
+      }
+    };
+
+    const user = await this.context.accessors.sdk.security.createUser(null, userBody);
+
+    return { kuid: user._id };
   }
 
   /**
@@ -231,9 +233,19 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<boolean>}
    */
-  exists(request, kuid, provider) {
-    return this.getCredentialsFromKuid(kuid, provider)
-      .then(credentials => Promise.resolve(credentials !== null));
+  async exists(request, kuid, provider) {
+    try {
+      await this.getCredentialsFromKuid(kuid, provider);
+
+      return true;
+    }
+    catch (error) {
+      if (!(error instanceof this.context.errors.NotFoundError)) {
+        throw error;
+      }
+
+      return false;
+    }
   }
 
   /**
@@ -245,22 +257,23 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  create(request, credentials, kuid, provider) {
-    let user = {};
+  async create(request, credentials, kuid, provider) {
+    const user = {};
 
-    return this.exists(request, kuid, provider)
-      .then(exists => {
-        if (exists) {
-          return Promise.reject(new this.context.errors.BadRequestError('A strategy already exists for this user.'));
-        }
-        Object.keys(credentials).forEach(attr => {
-          user[attr] = credentials[attr];
-        });
-        user.kuid = kuid;
-        user._id = credentials[this.config.strategies[provider].identifierAttribute];
+    const exists = await this.exists(request, kuid, provider);
 
-        return this.getProviderRepository(provider).create(user);
-      });
+    if (exists) {
+      throw new this.context.errors.BadRequestError(`A strategy already exists for the user "${kuid}".`);
+    }
+
+    for (const [attribute, value] of Object.entries(credentials)) {
+      user[attribute] = value;
+    }
+
+    user.kuid = kuid;
+    user._id = credentials[this.config.strategies[provider].identifierAttribute];
+
+    return this.getProviderRepository(provider).create(user);
   }
 
   /**
@@ -272,17 +285,13 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  update(request, credentials, kuid, provider) {
-    return this.getCredentialsFromKuid(kuid, provider)
-      .then(document => {
-        if (document === null) {
-          return Promise.reject(new this.context.errors.BadRequestError('A strategy does not exist for this user.'));
-        }
+  async update(request, credentials, kuid, provider) {
+    const credentialsObject = await this.getCredentialsFromKuid(kuid, provider);
 
-        return this.getProviderRepository(provider).update(
-          Object.assign({_id: document._id}, credentials)
-        );
-      });
+    return this.getProviderRepository(provider).update({
+      _id: credentialsObject._id,
+      ...credentials
+    });
   }
 
   /**
@@ -293,15 +302,12 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  delete(request, kuid, provider) {
-    return this.getCredentialsFromKuid(kuid, provider)
-      .then(document => {
-        if (document === null) {
-          return Promise.reject(new this.context.errors.BadRequestError('A strategy does not exist for this user.'));
-        }
+  async delete(request, kuid, provider) {
+    const credentials = await this.getCredentialsFromKuid(kuid, provider);
 
-        return this.getProviderRepository(provider).delete(document._id, {refresh: 'wait_for'});
-      });
+    return this.getProviderRepository(provider).delete(
+      credentials._id,
+      { refresh: 'wait_for' });
   }
 
   /**
@@ -313,21 +319,30 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  validate(request, credentials, kuid, provider, isUpdate) {
-    if (!isUpdate && !credentials[this.config.strategies[provider].identifierAttribute]) {
-      return Promise.reject(new this.context.errors.BadRequestError(''));
-    }
-    return this.getProviderRepository(provider).get(credentials[this.config.strategies[provider].identifierAttribute])
-      .then(result => {
-        if (result === null) {
-          return Promise.resolve(true);
-        }
+  async validate(request, credentials, kuid, provider, isUpdate) {
+    const identifierAttribute = this.config.strategies[provider].identifierAttribute;
 
-        if (kuid !== result.kuid) {
-          return Promise.reject(new this.context.errors.BadRequestError(`Id '${credentials[this.config.strategies[provider].identifierAttribute]}' is already used.`));
-        }
-        return Promise.resolve(true);
-      });
+    const credentialsIdentifier = credentials[identifierAttribute];
+
+    if (!isUpdate && !credentialsIdentifier) {
+      throw new this.context.errors.BadRequestError(`Missing "${identifierAttribute}" attribute value. This attribute must be present in the "persist" array.`);
+    }
+
+    try {
+      const result = await this.getProviderRepository(provider).get(credentialsIdentifier);
+
+      if (result.kuid !== kuid) {
+        throw new this.context.errors.BadRequestError(`IdentifierAttribute "${credentialsIdentifier}" is already used.`);
+      }
+    }
+    catch (error) {
+      // If the user already exists, when cannot create it
+      if (error.id !== 'services.storage.not_found') {
+        throw error;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -339,17 +354,13 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  getInfo(request, kuid, provider) {
-    return this.getCredentialsFromKuid(kuid, provider)
-      .then(info => {
-        if (info === null) {
-          return Promise.reject(new this.context.errors.BadRequestError('A strategy does not exist for this user.'));
-        }
+  async getInfo(request, kuid, provider) {
+    const credentials = await this.getCredentialsFromKuid(kuid, provider);
 
-        delete info._id;
-        delete info.kuid;
-        return Promise.resolve(info);
-      });
+    delete credentials._id;
+    delete credentials.kuid;
+
+    return credentials;
   }
 
   /**
@@ -360,16 +371,65 @@ class PluginPassportOAuth {
    * @param provider
    * @returns {Promise|Promise.<TResult>}
    */
-  getById(request, id, provider) {
-    return this.getProviderRepository(provider).get(id)
-      .then(result => {
-        if (result === null) {
-          return Promise.reject(new this.context.errors.BadRequestError('A strategy does not exist for this user.'));
-        }
+  async getById(request, id, provider) {
+    try {
+      return await this.getProviderRepository(provider).get(id);
+    }
+    catch (error) {
+      if (error.id === 'services.storage.not_found') {
+        throw new this.context.errors.BadRequestError(`A strategy does not exist for the user "${id}".`);
+      }
 
-        return Promise.resolve(result);
-      });
+      throw error;
+    }
   }
+}
+
+/**
+ * Returns an object with flattened keys
+ *
+ * Example!
+ * {
+ *   nested: {
+ *     value: 'aschen'
+ *   }
+ * }
+ * will return
+ * {
+ *   'nested.value': 'aschen'
+ * }
+ * @param {Object} object
+ *
+ * @returns {Object}
+ */
+function flatObject(object) {
+  const flattenedObject = {};
+
+  function walkObject(obj, path = '') {
+    for (const [key, value] of Object.entries(obj)) {
+      let currentPath;
+      if (Array.isArray(obj)) {
+        currentPath = path + `[${key}]`;
+      }
+      else if (path === '') {
+        currentPath = key;
+      }
+      else {
+        currentPath = `${path}.${key}`;
+      }
+
+      if (typeof value === 'object') {
+        walkObject(value, currentPath);
+      }
+      else {
+        flattenedObject[currentPath] = value;
+      }
+    }
+  }
+
+  walkObject(object);
+
+  return flattenedObject;
 }
 
 module.exports = PluginPassportOAuth;

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,6 @@ class PluginPassportOAuth {
    */
   constructor() {
     this.context = null;
-    this.scope = {};
     this.config = null;
     this.authenticators = {};
     this.strategies = {};
@@ -52,10 +51,6 @@ class PluginPassportOAuth {
     if (!this.config.strategies || Object.keys(this.config.strategies).length === 0) {
       this.context.log.warn('No strategies specified.');
       return;
-    }
-
-    for (const [strategy, definition] of Object.keys(this.config.strategies)) {
-      this.scope[strategy] = definition.scope;
     }
 
     await this.context.accessors.storage.bootstrap(this.storageMappings);

--- a/package-lock.json
+++ b/package-lock.json
@@ -962,8 +962,12 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lolex": {
       "version": "2.7.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Kuzzle plugin to log-in users through passport's strategies",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "eslint --max-warnings=0 ./lib ./test && nyc --reporter=text-summary --reporter=lcov mocha"
+    "test": "npm run test:lint && npm run test:unit",
+    "test:unit": "nyc --reporter=text-summary --reporter=lcov mocha",
+    "test:lint": "eslint --max-warnings=0 ./lib ./test",
+    "test:lint:fix": "eslint --fix --max-warnings=0 ./lib ./test"
   },
   "repository": {
     "type": "git",
@@ -25,6 +28,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "lodash.get": "^4.4.2",
+    "lodash.set": "^4.3.2",
     "passport": "^0.4.1",
     "passport-facebook": "^2.1.1",
     "passport-github": "^1.1.0",

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -18,7 +18,8 @@ describe('#create', () => {
 
   it('should reject if the user already exists', () => {
     pluginOauth.exists = sinon.stub().resolves(true);
-    return should(pluginOauth.create()).be.rejectedWith('A strategy already exists for this user.');
+
+    return should(pluginOauth.create()).be.rejected();
   });
 
   it('should create a user', () => {

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -4,9 +4,8 @@ const
   sinon = require('sinon');
 
 describe('#delete', () => {
-  let
-    pluginOauth,
-    pluginContext = require('./mock/pluginContext.mock.js');
+  let pluginOauth;
+  let pluginContext = require('./mock/pluginContext.mock.js');
 
   beforeEach(() => {
     sinon.restore();
@@ -17,7 +16,8 @@ describe('#delete', () => {
 
   it('should reject if the user doesn\'t exists', () => {
     pluginOauth.getCredentialsFromKuid = sinon.stub().resolves(null);
-    return should(pluginOauth.delete()).be.rejectedWith('A strategy does not exist for this user.');
+
+    return should(pluginOauth.delete()).be.rejected();
   });
 
   it('should delete a user', () => {
@@ -25,6 +25,7 @@ describe('#delete', () => {
 
     pluginOauth.getProviderRepository = sinon.stub().returns({delete: del});
     pluginOauth.getCredentialsFromKuid = sinon.stub().resolves({_id: 'foo'});
+
     return pluginOauth.delete()
       .then(() => should(del.calledOnce).be.true());
   });

--- a/test/exists.test.js
+++ b/test/exists.test.js
@@ -5,20 +5,24 @@ const
 
 describe('#exists', () => {
   let pluginOauth;
+  let pluginContext = require('./mock/pluginContext.mock.js');
 
   beforeEach(() => {
     sinon.restore();
     pluginOauth = new PluginOAuth();
     pluginOauth.getProviderRepository = sinon.stub();
+    pluginOauth.context = pluginContext;
   });
 
   it('should resolve true if user exists', () => {
     pluginOauth.getCredentialsFromKuid = sinon.stub().resolves({_id: '42'});
+
     return should(pluginOauth.exists()).be.fulfilledWith(true);
   });
 
   it('should resolve false if user doesn\'t exists', () => {
-    pluginOauth.getCredentialsFromKuid = sinon.stub().resolves(null);
+    pluginOauth.getCredentialsFromKuid = sinon.stub().rejects(new pluginContext.errors.NotFoundError('not found'));
+
     return should(pluginOauth.exists()).be.fulfilledWith(false);
   });
 });

--- a/test/getById.test.js
+++ b/test/getById.test.js
@@ -4,9 +4,8 @@ const
   sinon = require('sinon');
 
 describe('#getById', () => {
-  let
-    pluginOauth,
-    pluginContext = require('./mock/pluginContext.mock.js');
+  let pluginOauth;
+  let pluginContext = require('./mock/pluginContext.mock.js');
 
   beforeEach(() => {
     sinon.restore();
@@ -16,8 +15,8 @@ describe('#getById', () => {
   });
 
   it('should reject because the user doesn\'t exist', () => {
-    pluginOauth.getProviderRepository = sinon.stub().returns({get: sinon.stub().resolves(null)});
-    return should(pluginOauth.getById(null, '42')).be.rejectedWith('A strategy does not exist for this user.');
+    pluginOauth.getProviderRepository = sinon.stub().returns({get: sinon.stub().rejects()});
+    return should(pluginOauth.getById(null, '42')).be.rejected();
   });
 
   it('should resolve true', () => {

--- a/test/getCredentialsFromKuid.test.js
+++ b/test/getCredentialsFromKuid.test.js
@@ -4,23 +4,24 @@ const
   sinon = require('sinon');
 
 describe('#getCredentialsFromKuid', () => {
-  let
-    pluginOauth;
-  
+  let pluginOauth;
+  let pluginContext = require('./mock/pluginContext.mock.js');
+
   beforeEach(() => {
     sinon.restore();
     pluginOauth = new PluginOAuth();
+    pluginOauth.context = pluginContext;
   });
 
-  it('should resolve with a null result', () => {
+  it('should rejects if no credentials can be found', () => {
     pluginOauth.getProviderRepository = sinon.stub().returns({
       search: sinon.stub().resolves({total: 0})
     });
 
-    return should(pluginOauth.getCredentialsFromKuid(null, null)).be.fulfilledWith(null);
+    return should(pluginOauth.getCredentialsFromKuid(null, null)).be.rejected();
   });
 
-  it('should resolve with a null result', () => {
+  it('should resolve with the credentials', () => {
     pluginOauth.getProviderRepository = sinon.stub().returns({
       search: sinon.stub().resolves({total: 1, hits: [{id: 'foo'}]})
     });

--- a/test/getInfo.test.js
+++ b/test/getInfo.test.js
@@ -4,9 +4,8 @@ const
   sinon = require('sinon');
 
 describe('#getInfo', () => {
-  let
-    pluginOauth,
-    pluginContext = require('./mock/pluginContext.mock.js');
+  let pluginOauth;
+  let pluginContext = require('./mock/pluginContext.mock.js');
 
   beforeEach(() => {
     sinon.restore();
@@ -16,8 +15,9 @@ describe('#getInfo', () => {
   });
 
   it('should reject because the user doesn\'t exist', () => {
-    pluginOauth.getCredentialsFromKuid = sinon.stub().resolves(null);
-    return should(pluginOauth.getInfo(null, {_id: 'foo'})).be.rejectedWith('A strategy does not exist for this user.');
+    pluginOauth.getCredentialsFromKuid = sinon.stub().rejects(new Error());
+
+    return should(pluginOauth.getInfo(null, {_id: 'foo'})).be.rejected();
   });
 
   it('should resolve the info without _id', () => {

--- a/test/mock/pluginContext.mock.js
+++ b/test/mock/pluginContext.mock.js
@@ -14,7 +14,12 @@ module.exports = {
     storage: {
       bootstrap: sinon.stub().resolves()
     },
-    execute: sinon.stub().resolves({ result: { _id: '42' } })
+    sdk: {
+      security: {
+        createUser: sinon.stub().resolves()
+      }
+    },
+    execute: sinon.stub().resolves()
   },
   errors: {
     BadRequestError: defaultError,

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -16,8 +16,9 @@ describe('#update', () => {
   });
 
   it('should reject if the user doesn\'t exists', () => {
-    pluginOauth.getCredentialsFromKuid = sinon.stub().resolves(null);
-    return should(pluginOauth.update()).be.rejectedWith('A strategy does not exist for this user.');
+    pluginOauth.getCredentialsFromKuid = sinon.stub().rejects(new Error());
+
+    return should(pluginOauth.update()).be.rejected();
   });
 
   it('should update a user', () => {
@@ -25,6 +26,7 @@ describe('#update', () => {
 
     pluginOauth.getProviderRepository = sinon.stub().returns({update});
     pluginOauth.getCredentialsFromKuid = sinon.stub().resolves({_id: 'foo'});
+
     return pluginOauth.update()
       .then(() => {
         should(update.calledOnce).be.true();

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -16,24 +16,30 @@ describe('#validate', () => {
     pluginOauth.config = {strategies: {local: {identifierAttribute: '_id'}}};
   });
 
-  it('should resolve true if the user doesn\'t exists', () => {
-    const get = sinon.stub().resolves(null);
+  it('should resolve with true if the user doesn\'t exists', () => {
+    const get = sinon.stub().resolves({ kuid: '42' });
 
     pluginOauth.getProviderRepository = sinon.stub().returns({get});
-    return should(pluginOauth.validate(null, {_id: 'foo'}, '42', 'local')).be.fulfilledWith(true);
+
+    return should(pluginOauth.validate(null, {_id: 'foo'}, '42', 'local'))
+      .be.fulfilledWith(true);
   });
 
-  it('should reject a promise if the kuid is not equal to the fetched user', () => {
+  it('should rejects if the kuid is not equal to the fetched user', () => {
     const get = sinon.stub().resolves({kuid: '42'});
 
     pluginOauth.getProviderRepository = sinon.stub().returns({get});
-    return should(pluginOauth.validate(null, {_id: '0'}, '0', 'local')).be.rejectedWith('Id \'0\' is already used.');
+
+    return should(pluginOauth.validate(null, {_id: '0'}, '0', 'local'))
+      .be.rejected();
   });
 
   it('should resolve true', () => {
     const get = sinon.stub().resolves({kuid: '42'});
 
     pluginOauth.getProviderRepository = sinon.stub().returns({get});
-    return should(pluginOauth.validate(null, {_id: '42'}, '42', 'local')).be.fulfilledWith(true);
+
+    return should(pluginOauth.validate(null, {_id: '42'}, '42', 'local'))
+      .be.fulfilledWith(true);
   });
 });


### PR DESCRIPTION
## What does this PR do ?

Since Kuzzle v2, `Repository.get` rejects instead of returning a `null` value.

This PR fix the plugin to support this change.

Also indirectly fix https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth/issues/36 

### How should this be manually tested?

Use this configuration:
```
{
  "plugins":{
    "kuzzle-plugin-auth-passport-oauth": {
      "strategies": {
        "facebook": {
            "passportStrategy": "facebook",
            "credentials": {
                "clientID": "APP ID",
                "clientSecret": "APP SECRET",
                "callbackURL": "http://localhost:7512/_login/facebook",
                "profileFields": ["id", "name", "picture", "email"]
            },
            "persist": [
                "last_name",
                "first_name",
                "picture.data.url",
                "email"
            ],
            "scope": [
                "email",
                "public_profile"
            ],
            "kuzzleAttributesMapping": {
              "userMail": "email",
              "last_name": "fb.last_name",
              "first_name": "fb.first_name"
            },
            "identifierAttribute": "email"
        }
      }
    },
    "defaultProfiles": [ "default"]
  }
}
```

Then visit http://localhost:7512/_login/facebook

Check the user content in the admin console

### Other changes

 - use lodash to persist nested attribute (eg: `picture.data.url`)
 - better errors
 - improve readme

### Boyscout

  - use async/await
  - new code indent rules