### PR TITLE
Reverse profile mapping so path can be determined and mapped correctly.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const refresh = require('passport-oauth2-refresh');
 const assert = require('assert');
+const _ = require('lodash');
 
 /**
  * @class PluginPassportOAuth
@@ -193,14 +194,17 @@ class PluginPassportOAuth {
         if (this.config.strategies[profile.provider].persist.length === 0) {
           throw new this.context.errors.NotFoundError('There is nothing to persist in the plugin configuration.');
         }
-        Object.keys(profile._json).forEach(attr => {
-          if (this.config.strategies[profile.provider].persist.indexOf(attr) > -1) {
+        this.config.strategies[profile.provider].persist.forEach(attr => {
+          // Retrieve the value from the profile if it exists
+          const attrValue = _.get(profile._json, attr, undefined);
+          if (attrValue) {
+            // Apply any configured mapping
             if (this.config.strategies[profile.provider].kuzzleAttributesMapping) {
               const key = this.config.strategies[profile.provider].kuzzleAttributesMapping && this.config.strategies[profile.provider].kuzzleAttributesMapping[attr] || attr;
-              user[key] = profile._json[attr];
-              user[this.config.strategies[profile.provider].kuzzleAttributesMapping[attr]||attr] = profile._json[attr];
+              user[key] = attrValue;
+              user[this.config.strategies[profile.provider].kuzzleAttributesMapping[attr]||attr] = attrValue;
             } else {
-              user[attr] = profile._json[attr];
+              user[attr] = attrValue;
             }
           }
         });


### PR DESCRIPTION
<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
Resolves profile mapping for deeply nested profile fields. I.e. Facebook's profile picture url which resides at `profile.data.url`. It's important to note that lodash was used to resolve the deeply nesting path resolution.

### How should this be manually tested?

  - Step 1 : Define a deeply nested property to persist in .kuzzlerc under `kuzzle-plugin-auth-passport-oauth.strategies.facebook.persist`. For me this meant my persist collection looks like this; 

```
"persist": [
  "last_name",
  "first_name",
  "picture.data.url",   <-- This is my deeply nested property.
  "email"
],
```

Optional:
I also wanted to ensure the attribute mapping still worked so I also configured mapping as per below;

```
"kuzzleAttributesMapping": {
   "userMail": "email",
   "last_name": "fb.last_name",
   "first_name": "fb.first_name",
    "picture.data.url": "fb.profile_url"
},
```

  - Step 2 : Ensure your user has been removed from Kuzzle if you have previously authenticated with Facebook.  
  - Step 3 :  Navigate to http://localhost:7512/_login/facebook to authenticate.
  - Step 4:  Verify the user exists in the Admin Console and contains the "fb.profile_url" attribute.

### Other changes
Nil

### Boyscout
Comments to code 
