### PR TITLE
Update passport dependencies for facebook, google, oauth2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "passport": "^0.4.1",
-    "passport-facebook": "^2.1.1",
+    "passport-facebook": "^3.0.0",
     "passport-github": "^1.1.0",
-    "passport-google-oauth": "^1.0.0",
-    "passport-google-oauth20": "^1.0.0",
-    "passport-oauth2": "^1.5.0",
-    "passport-oauth2-refresh": "^1.1.0",
+    "passport-google-oauth": "^2.0.0",
+    "passport-google-oauth20": "^2.0.0",
+    "passport-oauth2": "^1.6.1",
+    "passport-oauth2-refresh": "^2.1.0",
     "passport-twitter": "^1.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What does this PR do ?

It updates the NPM dependencies for `passport-facebook`, `passport-google-oauth`, `passport-google-oauth20`, `passport-oauth2` and `passport-oauth2-refresh`. See issue https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth/issues/45 for rationale.

### How should this be manually tested?

Set up client apps in the respective providers (Facebook, Google, or other providers offering OAuth2), configure the `kuzzle-plugin-auth-passport-oauth` plugin, and test.