### PR TITLE
Release 5.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-oauth",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-oauth",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Kuzzle plugin to log-in users through passport's strategies",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
# [5.0.4](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth/releases/tag/5.0.4) (2021-10-18)


#### Enhancements

- [ [#46](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth/pull/46) ] Update passport dependencies for facebook, google, oauth2   ([MShekow](https://github.com/MShekow))
---

